### PR TITLE
New grant types

### DIFF
--- a/examples/password.ts
+++ b/examples/password.ts
@@ -11,12 +11,15 @@ global.Request = require("node-fetch").Request;
   const newFetch = fetchMwOAuth2({
     clientId: '...',
     clientSecret: '...',
-    grantType: 'client_credentials',
+    grantType: 'password',
     tokenEndpoint: 'https://auth-server.example.org/token',
     scope: ['foo', 'bar'],
+    userName: '...',
+    password: '...',
   });
 
-  const response = await newFetch('https://resource-server.example.org');
+  const response = await newFetch('https://resource-server.example.org/');
   console.log(response.status);
+  await wait();
 
 })();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,34 @@
+type PasswordGrantOptions = {
+  clientId: string,
+  clientSecret: string,
+  grantType: 'password',
+  tokenEndpoint: string,
+  scope?: string[],
+  userName: string,
+  password: string,
+};
+
+type ClientCredentialsGrantOptions = {
+  clientId: string,
+  clientSecret: string,
+  grantType: 'client_credentials',
+  tokenEndpoint: string,
+  scope?: string[],
+};
+
+export type OAuth2Options = PasswordGrantOptions | ClientCredentialsGrantOptions;
+
+export type AccessTokenRequest = {
+  grant_type: 'client_credentials',
+  scope?: string,
+} | {
+  grant_type: 'password',
+  username: string,
+  password: string,
+  scope?: string,
+} | {
+  grant_type: 'refresh_token',
+  refresh_token: string,
+  scope?: string,
+};
+


### PR DESCRIPTION
1. Support for the `password` grant_type
2. Automatically refresh tokens if they are expiring.
3. Use `refresh_token` grant if a refresh token is available, otherwise fall back on full-reauth

* Fixes #10 
* Fixes #3