### PR TITLE
Refactored into a class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,16 @@
 Changelog
 =========
 
-0.2.1 (????-??-??)
+0.3.0 (????-??-??)
+------------------
+
+* Library is refactored and now uses a class.
+* Support for `authorization_code` grant type.
+* Exposing some more information to uses.
+* Add a new `onTokenUpdate` hook for custom storage.
+
+
+0.2.1 (2019-03-13)
 ------------------
 
 * Shipping `dist/` instead of `src/`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-mw-oauth2",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Fetch middleware to add OAuth2 support",
   "main": "dist/index.js",
   "scripts": {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,47 +1,175 @@
 import { encode as base64Encode } from './base64';
-import { AccessTokenRequest, OAuth2Options } from './types';
+import { AccessTokenRequest, OAuth2Options, Token } from './types';
 import { objToQueryString } from './util';
 
-type Token = {
-  accessToken: string,
-  expiresAt: number | null,
-  refreshToken: string | null,
-};
+export default class OAuth2 {
 
-export default (options: OAuth2Options): typeof fetch => {
+  options: OAuth2Options;
+  token: Token;
 
-  let token: Token = {
-    accessToken: '',
-    expiresAt: 0,
-    refreshToken: null,
-  };
+  constructor(options: OAuth2Options) {
 
-  return async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+    this.options = options;
+    this.token = {
+      accessToken: '',
+      expiresAt: 0,
+      refreshToken: null
+    };
+
+  }
+
+  /**
+   * Does a fetch request and adds a Bearer / access token.
+   *
+   * If the access token is not known, this function attempts to fetch it
+   * first. If the access token is almost expiring, this function might attempt
+   * to refresh it.
+   */
+  async fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
 
     // input might be a string or a Request object, we want to make sure this
     // is always a fully-formed Request object.
     const request = new Request(input, init);
 
-    if (!token || (token.expiresAt !== null && token.expiresAt < Date.now())) {
-      token = await getToken(options, token);
-    }
+    let accessToken = await this.getAccessToken();
 
-    let response = await requestWithBearerToken(request, token.accessToken);
+    let response = await requestWithBearerToken(request, accessToken);
 
     if (!response.ok && response.status === 401) {
 
-      // We got a 401, lets try to re-authenticate
-      token = await getToken(options, token);
+      accessToken = await this.refreshToken();
 
       // We will try one more time
-      response = await requestWithBearerToken(request, token.accessToken);
+      response = await requestWithBearerToken(request, accessToken);
 
     }
     return fetch(request);
 
-  };
+  }
 
-};
+  /**
+   * Returns an access token.
+   *
+   * If the current access token is not known, it will attempt to fetch it.
+   * If the access token is expiring, it will attempt to refresh it.
+   */
+  async getAccessToken(): Promise<string> {
+
+    if (this.token.expiresAt === null || this.token.expiresAt > Date.now()) {
+
+      // The current token is still valid
+      return this.token.accessToken;
+
+    }
+
+    return this.refreshToken();
+
+  }
+
+  /**
+   * Forces an access token refresh
+   */
+  async refreshToken(): Promise<string> {
+
+    // The request body for the OAuth2 token endpoint
+    let body: AccessTokenRequest;
+
+    const previousToken = this.token;
+
+    if (previousToken.refreshToken) {
+      body = {
+        grant_type: 'refresh_token',
+        refresh_token: previousToken.refreshToken
+      };
+
+    } else {
+      switch (this.options.grantType) {
+
+        case 'client_credentials':
+          body = {
+            grant_type: 'client_credentials',
+          };
+          if (this.options.scope) {
+            body.scope = this.options.scope.join(' ');
+          }
+          break;
+        case 'password':
+          body = {
+            grant_type: 'password',
+            username: this.options.userName,
+            password: this.options.password,
+          };
+          if (this.options.scope) {
+            body.scope = this.options.scope.join(' ');
+          }
+          break;
+        case 'authorization_code' :
+          body = {
+            grant_type: 'authorization_code',
+            code: this.options.code,
+            redirect_uri: this.options.redirectUri,
+            client_id: this.options.clientId,
+          };
+          break;
+        default :
+          throw new Error('Unknown grantType: ' + this.options!.grantType);
+      }
+
+    }
+
+    const headers: {[s: string]: string} = {
+      'Content-Type'  : 'application/x-www-form-urlencoded',
+    };
+
+    if (this.options.grantType !== 'authorization_code') {
+      const basicAuthStr = base64Encode(this.options.clientId + ':' + this.options.clientSecret);
+      headers.Authorization = 'Basic ' + basicAuthStr;
+    }
+
+    const authResult = await fetch(this.options.tokenEndpoint, {
+      method: 'POST',
+      headers,
+      body: objToQueryString(body),
+    });
+
+    const jsonResult = await authResult.json();
+
+    if (!authResult.ok) {
+
+      // If we failed with a refresh_token grant_type, we're going to make one
+      // more attempt doing a full re-auth
+      if (body.grant_type === 'refresh_token') {
+        // Wiping out all old token info
+        this.token = {
+          accessToken: '',
+          expiresAt: 0,
+          refreshToken: null,
+        };
+        return this.getAccessToken();
+
+      }
+
+      let errorMessage = 'OAuth2 error ' + jsonResult.error + '.';
+      if (jsonResult.error_description) {
+        errorMessage += ' ' + jsonResult.error_description;
+      }
+      throw new Error(errorMessage);
+    }
+
+    this.token = {
+      accessToken: jsonResult.access_token,
+      expiresAt: jsonResult.expires_in ? Date.now() + (jsonResult.expires_in * 1000) : null,
+      refreshToken: jsonResult.refresh_token ? jsonResult.refresh_token : null,
+    };
+    if (this.options.onTokenUpdate) {
+      this.options.onTokenUpdate(this.token);
+    }
+
+    return this.token.accessToken;
+
+  }
+
+}
 
 async function requestWithBearerToken(request: Request, accessToken: string) {
 
@@ -49,77 +177,3 @@ async function requestWithBearerToken(request: Request, accessToken: string) {
   return await fetch(request);
 
 }
-
-const getToken = async (options: OAuth2Options, previousToken: Token): Promise<Token> => {
-
-  let body: AccessTokenRequest;
-
-  if (previousToken.refreshToken) {
-    body = {
-      grant_type: 'refresh_token',
-      refresh_token: previousToken.refreshToken
-    };
-
-  } else {
-    switch (options.grantType) {
-
-      case 'client_credentials':
-        body = {
-          grant_type: 'client_credentials',
-        };
-        break;
-      case 'password':
-        body = {
-          grant_type: 'password',
-          username: options.userName,
-          password: options.password,
-        };
-        break;
-      default :
-        throw new Error('Unknown grantType: ' + options!.grantType);
-    }
-    if (options.scope) {
-      body.scope = options.scope.join(' ');
-    }
-
-  }
-
-  const basicAuthStr = base64Encode(options.clientId + ':' + options.clientSecret);
-
-  const authResult = await fetch(options.tokenEndpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type'  : 'application/x-www-form-urlencoded',
-      'Authorization' : 'Basic ' + basicAuthStr,
-    },
-    body: objToQueryString(body),
-  });
-
-  const jsonResult = await authResult.json();
-
-  if (!authResult.ok) {
-
-    // If we failed with a refresh_token grant_type, we're going to make one
-    // more attempt doing a full re-auth
-    if (body.grant_type === 'refresh_token') {
-      return getToken(options, {
-        accessToken: '',
-        expiresAt: null,
-        refreshToken: null
-      });
-    }
-
-    let errorMessage = 'OAuth2 error ' + jsonResult.error + '.';
-    if (jsonResult.error_description) {
-      errorMessage += ' ' + jsonResult.error_description;
-    }
-    throw new Error(errorMessage);
-  }
-
-  return {
-    accessToken: jsonResult.access_token,
-    expiresAt: jsonResult.expires_in ? Date.now() + (jsonResult.expires_in * 1000) : null,
-    refreshToken: jsonResult.refresh_token ? jsonResult.refresh_token : null,
-  };
-
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,23 @@
-type PasswordGrantOptions = {
+/**
+ * Token information
+ */
+export type Token = {
+  accessToken: string,
+  expiresAt: number | null,
+  refreshToken: string | null,
+};
+
+
+/**
+ * The following types build the constructor options argument for
+ * the OAuth2 class.
+ */
+type BaseOptions = {
   clientId: string,
+  onTokenUpdate?: (token: Token) => void
+};
+
+type PasswordGrantOptions = {
   clientSecret: string,
   grantType: 'password',
   tokenEndpoint: string,
@@ -9,14 +27,22 @@ type PasswordGrantOptions = {
 };
 
 type ClientCredentialsGrantOptions = {
-  clientId: string,
   clientSecret: string,
   grantType: 'client_credentials',
   tokenEndpoint: string,
   scope?: string[],
 };
 
-export type OAuth2Options = PasswordGrantOptions | ClientCredentialsGrantOptions;
+type AuthorizationCodeGrantOptions = {
+  grantType: 'authorization_code',
+  redirectUri: string,
+  tokenEndpoint: string,
+  code: string,
+};
+
+export type OAuth2Options =
+  BaseOptions &
+  (PasswordGrantOptions | ClientCredentialsGrantOptions | AuthorizationCodeGrantOptions);
 
 export type AccessTokenRequest = {
   grant_type: 'client_credentials',
@@ -30,5 +56,10 @@ export type AccessTokenRequest = {
   grant_type: 'refresh_token',
   refresh_token: string,
   scope?: string,
+} | {
+  grant_type: 'authorization_code',
+  code: string,
+  redirect_uri: string,
+  client_id: string,
 };
 


### PR DESCRIPTION
I needed a way to expose existing tokens for storage, and this required more methods than just the main function.

This PR changes the entire library, which is now a class. It also adds `authorization_code` support.

* Updates #8 
* Fixes #7 