### PR TITLE
Added a getOptions method

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "webpack-cli": "^3.3.7"
   },
   "dependencies": {},
+  "browser": "browser/fetch-mw-oauth2.min.js",
   "files": [
     "dist/",
     "src/",

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -51,6 +51,48 @@ export default class OAuth2 {
   }
 
   /**
+   * After authenticating, this functions returns a set of options that may be
+   * used when authenticating the next time.
+   *
+   * You might for example want to store this in LocalStorage, allowing your
+   * application to remember any refresh / access tokens for next time.
+   *
+   * The result of this function can be used as the constructor argument for
+   * this object.
+   */
+  async getOptions(): Promise<OAuth2Options> {
+
+    const token = await this.getToken();
+
+    return {
+      clientId: this.options.clientId,
+      grantType: undefined,
+      accessToken: token.accessToken,
+      refreshToken: token.refreshToken || undefined,
+      tokenEndpoint: this.options.tokenEndpoint,
+    }
+
+  }
+
+  /**
+   * Returns current token information.
+   *
+   * There result object will have:
+   *   * accessToken
+   *   * expiresAt - when the token expires, or null.
+   *   * refreshToken - may be null
+   */
+  async getToken(): Promise<Token> {
+
+    /**
+     * We're running this function to make sure we get up-to-date information
+     */
+    await this.getAccessToken();
+    return this.token;
+
+  }
+
+  /**
    * Returns an access token.
    *
    * If the current access token is not known, it will attempt to fetch it.

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -70,7 +70,7 @@ export default class OAuth2 {
       accessToken: token.accessToken,
       refreshToken: token.refreshToken || undefined,
       tokenEndpoint: this.options.tokenEndpoint,
-    }
+    };
 
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,12 +55,12 @@ type AuthorizationCodeGrantOptions = {
  * In case you obtained an access token and/or refresh token through different
  * means, you can not specify a grant_type and simply only specifiy an access
  * and refresh token.
+ *
+ * If a refresh or tokenEndpoint are not supplied, the token will never get refreshed.
  */
 type RefreshOnlyGrantOptions = {
   grantType: undefined,
   accessToken: string,
-  refreshToken: string,
-  tokenEndpoint: string,
 };
 
 export type OAuth2Options =

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = [
     output: {
       path: __dirname + '/browser',
       filename: 'fetch-mw-oauth2.min.js',
-      library: 'fetchMwOAuth2'
+      library: 'fetchMwOAuth2',
+      libraryTarget: 'umd'
     },
 
     resolve: {
@@ -24,6 +25,5 @@ module.exports = [
     node: {
       Buffer: false
     }
-
-  },
+  }
 ];


### PR DESCRIPTION
This method can be used by applications to get all current token
information.

A browser client might want to use this to store refresh/accessToken
information into `LocalStorage`, so it can re-use them for even after a
refresh.