### PR TITLE
PKCE Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ If you already have an access and/or refresh token obtained through other
 means, you can set up the object as such:
 
 ```javascript
-const OAuth2 = require('fetch-mw-oauth2');
+const { OAuth2 } = require('fetch-mw-oauth2');
 
 const oauth2 = new OAuth2({
   clientId: '...',
   clientSecret: '...', // Optional in some cases
   accessToken: '...',
   refreshToken: '...',
-  tokenEndPoint: 'https://auth.example.org/token',
+  tokenEndpoint: 'https://auth.example.org/token',
 });
 
 const response = await oauth2.fetch('https://my-api.example.org/articles', {
-  method: 'POST'.
+  method: 'POST',
   body: 'Hello world',
 });
 ```
@@ -47,13 +47,14 @@ an `Authorization: Bearer ...` header.
 ### Setup via authorization_code grant
 
 ```javascript
-const OAuth2 = require('fetch-mw-oauth2');
+const { OAuth2 } = require('fetch-mw-oauth2');
 
 const oauth2 = new OAuth2({
   grantType: 'authorization_code',
   clientId: '...',
   code: '...',
-  tokenEndPoint: 'https://auth.example.org/token',
+  redirect_uri: 'https://my-app.example.org/cb',
+  tokenEndpoint: 'https://auth.example.org/token',
 });
 ```
 
@@ -66,7 +67,7 @@ the OAuth2 object.
 ### Setup via 'password' grant
 
 ```javascript
-const OAuth2 = require('fetch-mw-oauth2');
+const { OAuth2 } = require('fetch-mw-oauth2');
 
 const oauth2 = new OAuth2({
   grantType: 'password',
@@ -74,20 +75,20 @@ const oauth2 = new OAuth2({
   clientSecret: '...',
   userName: '...',
   password: '...',
-  tokenEndPoint: 'https://auth.example.org/token',
+  tokenEndpoint: 'https://auth.example.org/token',
 });
 ```
 
 ### Setup via 'client_credentials' grant
 
 ```javascript
-const OAuth2 = require('fetch-mw-oauth2');
+const { OAuth2 } = require('fetch-mw-oauth2');
 
 const oauth2 = new OAuth2({
   grantType: 'client_credentials',
   clientId: '...',
   clientSecret: '...',
-  tokenEndPoint: 'https://auth.example.org/token',
+  tokenEndpoint: 'https://auth.example.org/token',
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const oauth2 = new OAuth2({
   code: '...',
   redirect_uri: 'https://my-app.example.org/cb',
   tokenEndpoint: 'https://auth.example.org/token',
+  codeVerifier: '...' // Optional if PKCE wasn't used in authorization request
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const oauth2 = new OAuth2({
   code: '...',
   redirect_uri: 'https://my-app.example.org/cb',
   tokenEndpoint: 'https://auth.example.org/token',
-  codeVerifier: '...' // Optional if PKCE wasn't used in authorization request
+  codeVerifier: '...' // If PKCE was used in authorization request
 });
 ```
 

--- a/examples/authorization_code.ts
+++ b/examples/authorization_code.ts
@@ -14,6 +14,7 @@ global.Request = require("node-fetch").Request;
     code: '...',
     redirect_uri: 'https://resource-app.example.org/cb',
     tokenEndpoint: 'https://auth.example.org/token',
+    codeVerifier: '...' // Optional if PKCE wasn't used in authorization request
   });
 
   const response = await oauth2.fetch('https://resource-server.example.org/');

--- a/examples/authorization_code.ts
+++ b/examples/authorization_code.ts
@@ -12,7 +12,8 @@ global.Request = require("node-fetch").Request;
     grantType: 'authorization_code',
     clientId: '...',
     code: '...',
-    tokenEndPoint: 'https://auth.example.org/token',
+    redirect_uri: 'https://resource-app.example.org/cb',
+    tokenEndpoint: 'https://auth.example.org/token',
   });
 
   const response = await oauth2.fetch('https://resource-server.example.org/');

--- a/examples/client_credentials.ts
+++ b/examples/client_credentials.ts
@@ -12,7 +12,7 @@ global.Request = require("node-fetch").Request;
     grantType: 'client_credentials',
     clientId: '...',
     clientSecret: '...',
-    tokenEndPoint: 'https://auth.example.org/token',
+    tokenEndpoint: 'https://auth.example.org/token',
   });
 
   const response = await oauth2.fetch('https://resource-server.example.org/');

--- a/examples/password.ts
+++ b/examples/password.ts
@@ -14,7 +14,7 @@ global.Request = require("node-fetch").Request;
     clientSecret: '...',
     userName: '...',
     password: '...',
-    tokenEndPoint: 'https://auth.example.org/token',
+    tokenEndpoint: 'https://auth.example.org/token',
   });
 
   const response = await oauth2.fetch('https://resource-server.example.org/');

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -188,6 +188,7 @@ export default class OAuth2 {
             code: this.options.code,
             redirect_uri: this.options.redirectUri,
             client_id: this.options.clientId,
+            code_verifier: this.options.codeVerifier,
           };
           break;
         default :

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,11 +49,12 @@ type AuthorizationCodeGrantOptions = {
   grantType: 'authorization_code',
   redirectUri: string,
   code: string,
+  codeVerifier?: string,
 };
 
 /**
  * In case you obtained an access token and/or refresh token through different
- * means, you can not specify a grant_type and simply only specifiy an access
+ * means, you can not specify a grant_type and simply only specify an access
  * and refresh token.
  *
  * If a refresh or tokenEndpoint are not supplied, the token will never get refreshed.
@@ -85,5 +86,6 @@ export type AccessTokenRequest = {
   code: string,
   redirect_uri: string,
   client_id: string,
+  code_verifier?: string,
 };
 


### PR DESCRIPTION
Adds a new optional `codeVerifier` param to the `AuthorizationCodeGrantOptions` and passes `code_verifier` to the token request endpoint.

I also updated the examples and readme with some fixes.

Resolves #18 